### PR TITLE
Always unlock all mutexes

### DIFF
--- a/src/org/kde/kdeconnect/BackgroundService.java
+++ b/src/org/kde/kdeconnect/BackgroundService.java
@@ -350,11 +350,14 @@ public class BackgroundService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         //This will be called for each intent launch, even if the service is already started and it is reused
         mutex.lock();
-        for (InstanceCallback c : callbacks) {
-            c.onServiceStart(this);
+        try {
+            for (InstanceCallback c : callbacks) {
+                c.onServiceStart(this);
+            }
+            callbacks.clear();
+        } finally {
+            mutex.unlock();
         }
-        callbacks.clear();
-        mutex.unlock();
         return Service.START_STICKY;
     }
 
@@ -368,8 +371,11 @@ public class BackgroundService extends Service {
             public void run() {
                 if (callback != null) {
                     mutex.lock();
-                    callbacks.add(callback);
-                    mutex.unlock();
+                    try {
+                        callbacks.add(callback);
+                    } finally {
+                        mutex.unlock();
+                    }
                 }
                 Intent serviceIntent = new Intent(c, BackgroundService.class);
                 c.startService(serviceIntent);

--- a/src/org/kde/kdeconnect/Plugins/NotificationsPlugin/NotificationReceiver.java
+++ b/src/org/kde/kdeconnect/Plugins/NotificationsPlugin/NotificationReceiver.java
@@ -80,11 +80,14 @@ public class NotificationReceiver extends NotificationListenerService {
     public int onStartCommand(Intent intent, int flags, int startId) {
         //Log.e("NotificationReceiver", "onStartCommand");
         mutex.lock();
-        for (InstanceCallback c : callbacks) {
-            c.onServiceStart(this);
+        try {
+            for (InstanceCallback c : callbacks) {
+                c.onServiceStart(this);
+            }
+            callbacks.clear();
+        } finally {
+            mutex.unlock();
         }
-        callbacks.clear();
-        mutex.unlock();
         return Service.START_STICKY;
     }
 
@@ -96,8 +99,11 @@ public class NotificationReceiver extends NotificationListenerService {
     public static void RunCommand(Context c, final InstanceCallback callback) {
         if (callback != null) {
             mutex.lock();
-            callbacks.add(callback);
-            mutex.unlock();
+            try {
+                callbacks.add(callback);
+            } finally {
+                mutex.unlock();
+            }
         }
         Intent serviceIntent = new Intent(c, NotificationReceiver.class);
         c.startService(serviceIntent);


### PR DESCRIPTION
While looking through the code I noticed that in a few places ReentrantLocks are used as mutexes.  In case of an exception happening in the critical section the locks are never released though.  A  ReentrantLock should (almost) always be followed by a try-finally block as documented in
  http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/locks/ReentrantLock.html

I'm not saying that this is actually causing a bug right now but in case it happens this change will avoid some headaches :-)